### PR TITLE
Exit the JVM on OutOfMemoryError so the container restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM virtualflybrain/docker-vfb-neo4j:4.2-enterprise
 
 # Fix for log4j vulnerability
 ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
-ENV NEO4J_dbms_jvm_additional="-Dlog4j2.formatMsgNoLookups=true -Dlog4j2.disable.jmx=true"
+# Stop the JVM the moment the heap is exhausted, rather than letting it thrash
+# indefinitely in GC while still accepting connections. The entrypoint execs
+# `neo4j console`, so the JVM is the container's foreground process and its
+# exit stops the container, letting the orchestrator restart it cleanly.
+ENV NEO4J_dbms_jvm_additional="-Dlog4j2.formatMsgNoLookups=true -Dlog4j2.disable.jmx=true -XX:+ExitOnOutOfMemoryError"
 
 ENV NEOREADONLY=true
 


### PR DESCRIPTION
Replaces #2, which had the right idea but was never merged and has since gone stale against `master`.

**Nothing on `master` handles out-of-memory today.** I checked `Dockerfile`, `loadDB.sh` and `gds_projections.sh` — no `OutOfMemory` handling anywhere. The container currently has `NEO4J_dbms_memory_heap_maxSize=4G` and a 4G page cache, and on heap exhaustion the JVM will thrash in GC indefinitely while still holding its listeners open, so the endpoint looks up but answers nothing.

This adds one flag:

```
-XX:+ExitOnOutOfMemoryError
```

The JVM exits immediately on the first `OutOfMemoryError` instead of trying to continue. The 4.2 entrypoint runs `exec gosu neo4j:neo4j neo4j console`, so the JVM is the container's foreground process — its exit stops the container and the orchestrator restarts it. `NEO4J_dbms_read__only=true` is already set, so a hard stop cannot leave a half-written store.

**What I deliberately left out of #2.** That PR also added a ~70-line FIFO supervisor to `loadDB.sh` that killed the container on `java.io.IOException`. That is a different failure mode from memory, and its own comment says the default `CRASH_THRESHOLD=1` will restart the container on routine "Connection reset by peer" traffic — every client or proxy disconnect on a public endpoint. Worth having as its own change, with a threshold chosen deliberately, rather than riding along with the memory fix.

Also not included: `-XX:+HeapDumpOnOutOfMemoryError`. A 4 GB heap dump written into a production container on the way down costs more than it gives us here.

**Not covered by this:** a kernel/cgroup OOM-kill of the whole container, which bypasses the JVM entirely, and off-heap page-cache pressure. Those remain the orchestrator's restart policy to handle.